### PR TITLE
Ignore changesets where repo does not exist anymore (#9656)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Changesets on repositories that aren't available on the instance anymore are now hidden instead of failing. [#9656](https://github.com/sourcegraph/sourcegraph/pull/9656)
+
 ### Removed
 
 ## 3.14.0


### PR DESCRIPTION
When the repo is recloned, the changesets will reappear in the campaigns overview.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
